### PR TITLE
Fixing a 403 Forbidden error

### DIFF
--- a/simple-nws/Configuration.php
+++ b/simple-nws/Configuration.php
@@ -12,7 +12,7 @@ class Configuration
     /**
      * @var string constant The URL for the National Weather Service interface
      */
-    const C_NWS_URL = 'http://graphical.weather.gov/xml/sample_products/browser_interface/ndfdXMLclient.php?';
+    const C_NWS_URL = 'https://graphical.weather.gov/xml/sample_products/browser_interface/ndfdXMLclient.php?';
 
     /**
      * @var array The allowed values for the timeframe parameter

--- a/simple-nws/DWMLParser.php
+++ b/simple-nws/DWMLParser.php
@@ -1,5 +1,6 @@
 <?php
 namespace SimpleNWS;
+ini_set('user_agent','Mozilla/5.0'); 
 /**
  * Parser for NOAA's Digital Weather Markup Language
  *


### PR DESCRIPTION
Without this init, the API gives a 403 forbidden. The web page will be viewable by navigating to it in a web browser, but will give an error without a web browser. Below is the errors I received on /example.php when I first loaded the code. I also added https, as it is redirected anyway.

> Warning:  simplexml_load_file(https://graphical.weather.gov/xml/sample_products/browser_interface/ndfdXMLclient.php?lat=40.75&lon=-73.92&product=time-series&begin=2017-03-09T00:00:00-05:00&end=2017-03-16T00:00:00-04:00&maxt=maxt&mint=mint&temp=temp&appt=appt&wx=wx&qpf=qpf&snow=snow&sky=sky&wspd=wspd&wdir=wdir&rh=rh): failed to open stream: HTTP request failed! HTTP/1.0 403 Forbidden
 in /path/DWMLParser.php on line 57


>Warning:
  simplexml_load_file(): I/O warning : failed to load external entity "https://graphical.weather.gov/xml/sample_products/browser_interface/ndfdXMLclient.php?lat=40.75&lon=-73.92&product=time-series&begin=2017-03-09T00:00:00-05:00&end=2017-03-16T00:00:00-04:00&maxt=maxt&mint=mint&temp=temp&appt=appt&wx=wx&qpf=qpf&snow=snow&sky=sky&wspd=wspd&wdir=wdir&rh=rh" in /path/DWMLParser.php on line 57

>Empty response from the National Weather Service. Please try again later. 